### PR TITLE
feat(): add rsa pss document hash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/niclabs/tcrsa
 
 go 1.12
+
+require github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,1 +1,10 @@
-github.com/niclabs/libtc-rsa v0.0.0-20190415152758-2a15e45a7d0e h1:7lP0VhVtU+wzZVMiZkW5tdoPYrxP9HQETqWP0toMnnI=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkcs1_encoding_test.go
+++ b/pkcs1_encoding_test.go
@@ -1,9 +1,9 @@
-package tcrsa_test
+package tcrsa
 
 import (
 	"crypto"
 	"crypto/sha256"
-	"github.com/niclabs/tcrsa"
+
 	"testing"
 )
 
@@ -12,7 +12,7 @@ const pkcs1EncodingLeyLength = 64
 
 func TestPrepareDocumentHash(t *testing.T) {
 	docHash := sha256.Sum256([]byte(pkcs1EncodingTestMessage))
-	docPKCS1, err := tcrsa.PrepareDocumentHash(pkcs1EncodingLeyLength, crypto.SHA256, docHash[:])
+	docPKCS1, err := PrepareDocumentHash(pkcs1EncodingLeyLength, crypto.SHA256, docHash[:])
 	if err != nil {
 		t.Errorf("couldn't prepare document hash: %v", err)
 	}

--- a/pss_encoding.go
+++ b/pss_encoding.go
@@ -1,0 +1,140 @@
+package tcrsa
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+)
+
+// This method was copied from SignPSS function from crypto/rsa on https://golang.org/pkg/crypto/rsa/
+func PreparePssDocumentHash(privateKeySize int, hash crypto.Hash, hashed []byte, opts *rsa.PSSOptions) ([]byte, error) {
+	saltLength := (privateKeySize+7)/8 - 2 - hash.Size()
+
+	if saltLength <= 0 {
+		return nil, fmt.Errorf("message too long")
+	}
+	if opts != nil && opts.Hash != 0 {
+		hash = opts.Hash
+	}
+
+	salt := make([]byte, saltLength)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return nil, err
+	}
+
+	nBits := privateKeySize
+	em, err := emsaPSSEncode(hashed, nBits-1, salt, hash.New())
+	return em, err
+}
+
+func emsaPSSEncode(mHash []byte, emBits int, salt []byte, hash hash.Hash) ([]byte, error) {
+	// See [1], section 9.1.1
+	hLen := hash.Size()
+	sLen := len(salt)
+	emLen := (emBits + 7) / 8
+
+	// 1.  If the length of M is greater than the input limitation for the
+	//     hash function (2^61 - 1 octets for SHA-1), output "message too
+	//     long" and stop.
+	//
+	// 2.  Let mHash = Hash(M), an octet string of length hLen.
+
+	if len(mHash) != hLen {
+		return nil, errors.New("crypto/rsa: input must be hashed message")
+	}
+
+	// 3.  If emLen < hLen + sLen + 2, output "encoding error" and stop.
+
+	if emLen < hLen+sLen+2 {
+		return nil, errors.New("crypto/rsa: key size too small for PSS signature")
+	}
+
+	em := make([]byte, emLen)
+	db := em[:emLen-sLen-hLen-2+1+sLen]
+	h := em[emLen-sLen-hLen-2+1+sLen : emLen-1]
+
+	// 4.  Generate a random octet string salt of length sLen; if sLen = 0,
+	//     then salt is the empty string.
+	//
+	// 5.  Let
+	//       M' = (0x)00 00 00 00 00 00 00 00 || mHash || salt;
+	//
+	//     M' is an octet string of length 8 + hLen + sLen with eight
+	//     initial zero octets.
+	//
+	// 6.  Let H = Hash(M'), an octet string of length hLen.
+
+	var prefix [8]byte
+
+	hash.Write(prefix[:])
+	hash.Write(mHash)
+	hash.Write(salt)
+
+	h = hash.Sum(h[:0])
+	hash.Reset()
+
+	// 7.  Generate an octet string PS consisting of emLen - sLen - hLen - 2
+	//     zero octets. The length of PS may be 0.
+	//
+	// 8.  Let DB = PS || 0x01 || salt; DB is an octet string of length
+	//     emLen - hLen - 1.
+
+	db[emLen-sLen-hLen-2] = 0x01
+	copy(db[emLen-sLen-hLen-1:], salt)
+
+	// 9.  Let dbMask = MGF(H, emLen - hLen - 1).
+	//
+	// 10. Let maskedDB = DB \xor dbMask.
+
+	mgf1XOR(db, hash, h)
+
+	// 11. Set the leftmost 8 * emLen - emBits bits of the leftmost octet in
+	//     maskedDB to zero.
+
+	db[0] &= (0xFF >> uint(8*emLen-emBits))
+
+	// 12. Let EM = maskedDB || H || 0xbc.
+	em[emLen-1] = 0xBC
+
+	// 13. Output EM.
+	return em, nil
+}
+
+// incCounter increments a four byte, big-endian counter.
+func incCounter(c *[4]byte) {
+	if c[3]++; c[3] != 0 {
+		return
+	}
+	if c[2]++; c[2] != 0 {
+		return
+	}
+	if c[1]++; c[1] != 0 {
+		return
+	}
+	c[0]++
+}
+
+// mgf1XOR XORs the bytes in out with a mask generated using the MGF1 function
+// specified in PKCS#1 v2.1.
+func mgf1XOR(out []byte, hash hash.Hash, seed []byte) {
+	var counter [4]byte
+	var digest []byte
+
+	done := 0
+	for done < len(out) {
+		hash.Write(seed)
+		hash.Write(counter[0:4])
+		digest = hash.Sum(digest[:0])
+		hash.Reset()
+
+		for i := 0; i < len(digest) && done < len(out); i++ {
+			out[done] ^= digest[i]
+			done++
+		}
+		incCounter(&counter)
+	}
+}

--- a/pss_encoding_test.go
+++ b/pss_encoding_test.go
@@ -1,0 +1,24 @@
+package tcrsa
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPreparePssDocumentHash(t *testing.T) {
+	var (
+		pssEncodeTestMessage = "Hello World , Pss Encoding"
+		pssEncodingLeyLength = 4096
+	)
+
+	docHash := sha256.Sum256([]byte(pssEncodeTestMessage))
+	docPss, err := PreparePssDocumentHash(pssEncodingLeyLength, crypto.SHA256, docHash[:], &rsa.PSSOptions{
+		SaltLength: 0,
+		Hash:       crypto.SHA256,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, pssEncodingLeyLength/8, len(docPss))
+}


### PR DESCRIPTION
The original signature data encapsulation only supports RSA-PKCS algorithm, this PR adds RSA-PSS algorithm, I have tested it and will use it in our production, please pass it. thanks !!!